### PR TITLE
Fix blank page by adding offline fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,14 @@
     <title>3D World Experience</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.min.js"></script>
+    <script>
+        if (typeof THREE === 'undefined') {
+            window.addEventListener('DOMContentLoaded', function() {
+                document.body.innerHTML = '<h1 style="color:#000;text-align:center;margin-top:2rem">Unable to load 3D scene. Check internet connection.</h1>';
+                document.body.style.background = "#fff";
+            });
+        }
+    </script>
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
## Summary
- show an error message if Three.js fails to load

## Testing
- `node --check script.js` (failed: script.js removed)


------
https://chatgpt.com/codex/tasks/task_e_68826346402c832ab2c13f86ce45763f