### PR TITLE
Add demoscene showreel landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demoscene Showreel | Realtime JS + Audio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #05060d;
+      --glass: rgba(255, 255, 255, 0.06);
+      --accent: #7bffdf;
+      --accent-2: #ff8ce0;
+      --text: #e9f8ff;
+      --muted: #9fb3c8;
+      color-scheme: dark;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at 20% 20%, rgba(123, 255, 223, 0.14), transparent 30%),
+                  radial-gradient(circle at 80% 0%, rgba(255, 140, 224, 0.16), transparent 30%),
+                  radial-gradient(circle at 40% 80%, rgba(92, 169, 255, 0.12), transparent 25%),
+                  var(--bg);
+      overflow-x: hidden;
+    }
+    .scanlines {
+      pointer-events: none;
+      position: fixed;
+      inset: 0;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03),
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 3px
+      );
+      mix-blend-mode: soft-light;
+      opacity: 0.3;
+      animation: flicker 4s steps(3) infinite;
+    }
+    @keyframes flicker { 50% { opacity: 0.2; } 100% { opacity: 0.35; } }
+    .grid-bg {
+      position: fixed;
+      inset: 0;
+      background-image: linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+                        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+      background-size: 26px 26px;
+      mask-image: radial-gradient(circle at 50% 50%, black 0%, transparent 80%);
+      opacity: 0.4;
+      transform: perspective(600px) rotateX(72deg) translateY(-120px);
+      transform-origin: center;
+      animation: drift 18s linear infinite;
+      pointer-events: none;
+    }
+    @keyframes drift {
+      0% { background-position: 0 0, 0 0; }
+      100% { background-position: 0 120px, 120px 0; }
+    }
+    header {
+      padding: 48px min(6vw, 64px) 24px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 24px;
+      align-items: flex-end;
+      position: relative;
+      z-index: 1;
+    }
+    .brand {
+      flex: 1 1 320px;
+    }
+    h1 {
+      margin: 0;
+      font-size: clamp(32px, 4vw, 56px);
+      letter-spacing: 1px;
+      font-family: 'Orbitron', sans-serif;
+      text-transform: uppercase;
+      text-shadow: 0 0 32px rgba(123, 255, 223, 0.5);
+    }
+    .sub {
+      color: var(--muted);
+      margin-top: 8px;
+      max-width: 720px;
+      line-height: 1.6;
+    }
+    .cta-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    .pill {
+      background: linear-gradient(120deg, rgba(123, 255, 223, 0.2), rgba(255, 140, 224, 0.18));
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 999px;
+      padding: 10px 16px;
+      font-weight: 600;
+      color: var(--text);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.35);
+    }
+    .pill button {
+      all: unset;
+      cursor: pointer;
+      background: linear-gradient(120deg, var(--accent), var(--accent-2));
+      color: #0a0a0f;
+      padding: 10px 16px;
+      border-radius: 999px;
+      font-weight: 700;
+      box-shadow: 0 8px 20px rgba(123, 255, 223, 0.35);
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .pill button:hover { transform: translateY(-1px); box-shadow: 0 12px 30px rgba(255, 140, 224, 0.35); }
+    .grid {
+      position: relative;
+      z-index: 1;
+      padding: 12px min(6vw, 64px) 80px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+    }
+    .card {
+      background: rgba(10, 13, 22, 0.78);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 18px;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 12px;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 10px 38px rgba(0,0,0,0.35);
+      transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+    }
+    .card:before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(123, 255, 223, 0.2), transparent 36%),
+                  radial-gradient(circle at 90% 20%, rgba(255, 140, 224, 0.18), transparent 38%);
+      opacity: 0;
+      transition: opacity 200ms ease;
+      pointer-events: none;
+    }
+    .card:hover {
+      transform: translateY(-4px);
+      border-color: rgba(123, 255, 223, 0.35);
+      box-shadow: 0 18px 46px rgba(0,0,0,0.45);
+    }
+    .card:hover:before { opacity: 1; }
+    .badge-row { display: flex; gap: 8px; flex-wrap: wrap; }
+    .badge {
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .title {
+      font-family: 'Orbitron', sans-serif;
+      letter-spacing: 0.6px;
+      font-size: 18px;
+      margin: 0;
+    }
+    .desc {
+      color: var(--muted);
+      margin: 0;
+      line-height: 1.55;
+      min-height: 72px;
+    }
+    .actions { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+    .actions a {
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 14px;
+      letter-spacing: 0.4px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 14px;
+      border-radius: 10px;
+      background: linear-gradient(120deg, rgba(123,255,223,0.16), rgba(255,140,224,0.16));
+      border: 1px solid rgba(255,255,255,0.12);
+      transition: background 160ms ease, transform 160ms ease;
+    }
+    .actions a:hover { background: linear-gradient(120deg, rgba(123,255,223,0.3), rgba(255,140,224,0.3)); transform: translateY(-1px); }
+    .meta { color: var(--muted); font-size: 12px; letter-spacing: 0.3px; }
+    .footer {
+      padding: 0 min(6vw, 64px) 48px;
+      position: relative;
+      z-index: 1;
+      color: var(--muted);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .timeline {
+      padding: 0 min(6vw, 64px) 52px;
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: 16px;
+      max-width: 960px;
+      color: var(--muted);
+    }
+    .timeline h3 {
+      margin: 0;
+      font-family: 'Orbitron', sans-serif;
+      color: var(--text);
+      letter-spacing: 1px;
+    }
+    .timeline-item {
+      border-left: 2px solid rgba(123, 255, 223, 0.4);
+      padding-left: 14px;
+      position: relative;
+    }
+    .timeline-item::before {
+      content: '';
+      position: absolute;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      background: linear-gradient(120deg, var(--accent), var(--accent-2));
+      left: -6px; top: 6px;
+      box-shadow: 0 0 18px rgba(255, 140, 224, 0.6);
+    }
+    .timeline-item strong { color: var(--text); }
+    .hotkey {
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 8px;
+      padding: 10px 12px;
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      margin-left: auto;
+      font-size: 13px;
+    }
+    @media (max-width: 720px) {
+      header { padding-top: 32px; }
+      .actions { flex-direction: column; align-items: flex-start; }
+      .desc { min-height: unset; }
+      .pill { width: 100%; justify-content: space-between; }
+      .pill button { width: 100%; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+  <div class="grid-bg"></div>
+  <div class="scanlines"></div>
+  <header>
+    <div class="brand">
+      <h1>Realtime JS Demoscene Showreel</h1>
+      <p class="sub">A curated hub for our evolving set of WebGL experiments: neon cities, voxel worlds, shader studies, and audio-reactive art. Each card jumps straight into the runnable demo; perfect for big screens or quick inspiration bursts.</p>
+      <div class="cta-bar">
+        <div class="pill">
+          <span>Live showcase · <strong id="demo-count">0</strong> entries</span>
+          <button id="launch-first" type="button">Launch featured</button>
+        </div>
+        <div class="hotkey">↔ Navigate cards · Enter to open</div>
+      </div>
+    </div>
+  </header>
+
+  <main class="grid" id="cards"></main>
+
+  <section class="timeline">
+    <h3>Upcoming drops</h3>
+    <div class="timeline-item"><strong>Audio-reactive shader suite</strong> · FFT-driven post and glitch overlays tuned to live BPM.</div>
+    <div class="timeline-item"><strong>4k intro challenge</strong> · Minimal footprint WebGL intro targeting ultra-low byte budgets.</div>
+    <div class="timeline-item"><strong>Networked jam session</strong> · WebRTC sync so visitors can co-drive camera cues and lighting.</div>
+  </section>
+
+  <footer class="footer">
+    <div>Built for big speakers, ultra-wide screens, and the eternal glow of CRT scanlines.</div>
+    <div class="meta">Use ← → to browse · Enter to launch · Esc to reset focus</div>
+  </footer>
+
+  <script>
+    const demos = [
+      {
+        title: 'Euphoric Voxel Planet',
+        href: '3d-world.html',
+        tags: ['three.js', 'orbit', 'voxel vibe'],
+        desc: 'Sky islands, orbit controls, and saturated emissive materials for a painterly low-poly world.'
+      },
+      {
+        title: 'Chromatic Cityscape',
+        href: '3d-world-2.html',
+        tags: ['three.js', 'neon fog', 'infinite loop'],
+        desc: 'Procedural metropolis with animated holograms, rolling grid planes, and synth-laced lighting moods.'
+      },
+      {
+        title: 'Artifacts Gallery',
+        href: 'artifacts.html',
+        tags: ['shader toy', 'color grading', 'post fx'],
+        desc: 'Curated glitch captures, hand-tuned LUTs, and camera choreographies framed like VHS album art.'
+      },
+      {
+        title: 'VHDR Lab',
+        href: 'vhdr.html',
+        tags: ['hdr tone-map', 'audio sync', 'studio tool'],
+        desc: 'Tone-mapped vistas with subtle bloom layers; built as the staging ground for audio-reactive overlays.'
+      },
+      {
+        title: 'Empty slot · ready for your next idea',
+        href: '#',
+        tags: ['coming soon', 'shader graph'],
+        desc: 'Drop in a new fragment shader or physics playground; the card auto-adapts with metadata + hotkeys.',
+        disabled: true
+      }
+    ];
+
+    const cardsEl = document.getElementById('cards');
+    const demoCountEl = document.getElementById('demo-count');
+    const launchFirst = document.getElementById('launch-first');
+
+    const createCard = (demo, index) => {
+      const card = document.createElement('article');
+      card.className = 'card';
+      card.tabIndex = demo.disabled ? -1 : 0;
+      card.dataset.index = index;
+      card.dataset.disabled = demo.disabled ? 'true' : 'false';
+
+      const badges = demo.tags.map(tag => `<span class="badge">${tag}</span>`).join('');
+      const disabledText = demo.disabled ? '<div class="meta">Placeholder · wire in your next prototype</div>' : '';
+
+      card.innerHTML = `
+        <div class="badge-row">${badges}</div>
+        <div>
+          <h2 class="title">${demo.title}</h2>
+          <p class="desc">${demo.desc}</p>
+        </div>
+        <div class="actions">
+          <div class="meta">${demo.disabled ? 'Awaiting upload' : 'Ready to launch'}</div>
+          <a ${demo.disabled ? 'aria-disabled="true" style="opacity:0.4;cursor:not-allowed;"' : ''} href="${demo.href}" target="_blank" rel="noopener">Enter demo →</a>
+        </div>
+        ${disabledText}
+      `;
+
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        const centerX = rect.width / 2;
+        const centerY = rect.height / 2;
+        const rotateX = ((y - centerY) / centerY) * -3;
+        const rotateY = ((x - centerX) / centerX) * 3;
+        card.style.transform = `perspective(800px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) translateY(-2px)`;
+      });
+
+      card.addEventListener('mouseleave', () => {
+        card.style.transform = '';
+      });
+
+      card.addEventListener('click', () => {
+        if (!demo.disabled && demo.href !== '#') window.open(demo.href, '_blank');
+      });
+
+      return card;
+    };
+
+    const render = () => {
+      demoCountEl.textContent = demos.filter(d => !d.disabled).length;
+      demos.forEach((demo, i) => cardsEl.appendChild(createCard(demo, i)));
+    };
+
+    render();
+
+    launchFirst.addEventListener('click', () => {
+      const first = demos.find(d => !d.disabled && d.href !== '#');
+      if (first) window.open(first.href, '_blank');
+    });
+
+    let activeIndex = 0;
+    const focusCard = (index) => {
+      const cards = [...document.querySelectorAll('.card')].filter(c => c.dataset.disabled !== 'true');
+      if (cards.length === 0) return;
+      activeIndex = (index + cards.length) % cards.length;
+      cards.forEach(c => c.classList.remove('focused'));
+      const current = cards[activeIndex];
+      current.classList.add('focused');
+      current.focus({ preventScroll: false });
+    };
+
+    document.addEventListener('keydown', (e) => {
+      const cards = document.querySelectorAll('.card');
+      if (['ArrowRight', 'ArrowDown'].includes(e.key)) {
+        e.preventDefault();
+        focusCard(activeIndex + 1);
+      }
+      if (['ArrowLeft', 'ArrowUp'].includes(e.key)) {
+        e.preventDefault();
+        focusCard(activeIndex - 1);
+      }
+      if (e.key === 'Enter') {
+        const card = [...cards].filter(c => c.dataset.disabled !== 'true')[activeIndex];
+        if (card) {
+          const link = card.querySelector('a[href]:not([aria-disabled])');
+          link?.click();
+        }
+      }
+      if (e.key === 'Escape') {
+        activeIndex = 0;
+        focusCard(activeIndex);
+      }
+    });
+
+    focusCard(activeIndex);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an animated landing page for the demoscene showreel with neon styling, hero CTA, and scanline/grid background layers
- list current demos with hover tilt cards, launch buttons, and hotkey guidance for keyboard navigation
- include upcoming roadmap timeline and placeholder slot ready for the next experiment

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e39adb74832a8ee10cf5fea52c72)