### PR TITLE
Add “Cyclist Atlas” alias to CycleAtlas demo for discoverability

### DIFF
--- a/cycling_tracker.html
+++ b/cycling_tracker.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CycleAtlas — Tracker + Timeline</title>
+  <title>CycleAtlas (Cyclist Atlas) — Tracker + Timeline</title>
   <style>
     :root {
       --bg: #0b1220;
@@ -234,7 +234,7 @@
   <main class="app">
     <aside class="panel sidebar">
       <section class="section title">
-        <h1>🚴 CycleAtlas</h1>
+        <h1>🚴 CycleAtlas <span style="font-weight:500; opacity:0.8;">(Cyclist Atlas)</span></h1>
         <p>Track rides in a live app shell, then relive them in a visual calendar timeline.</p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
         <h1>Demo Index</h1>
         <ul>
             <li><a href="synapse_gallery.html">SYNAPSE:07 Scene &amp; Effect Gallery</a><small>Overview of scenes, transitions, and post FX for the warp edition.</small></li>
-            <li><a href="cycling_tracker.html">CycleAtlas — Cycling Tracker + Timeline</a><small>Google-Maps-style cycling tracker with calendar timeline voyage explorer.</small></li>
+            <li><a href="cycling_tracker.html">CycleAtlas (Cyclist Atlas) — Cycling Tracker + Timeline</a><small>Google-Maps-style cycling tracker with calendar timeline voyage explorer.</small></li>
             <li><a href="synapse_v0_7_0.html">SYNAPSE:07 Warp Edition</a><small>Original interactive experience with audio-reactive WebGL sequencing.</small></li>
             <li><a href="3d-world.html">3D World</a><small>Legacy three.js demo.</small></li>
             <li><a href="3d-world-2.html">3D World 2</a><small>Alternate scene graph experiment.</small></li>


### PR DESCRIPTION
### Motivation
- Improve findability by adding the alternate name "Cyclist Atlas" next to the existing `CycleAtlas` label so users searching for the alias can locate the demo.

### Description
- Updated the demo index entry in `index.html` to display `CycleAtlas (Cyclist Atlas)` and updated the `cycling_tracker.html` page `<title>` and `<h1>` to include `(Cyclist Atlas)` for consistent labeling.

### Testing
- Ran `git diff --check` to validate the patch format and confirmed no issues; changes were applied to `index.html` and `cycling_tracker.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97709122c832ab3cfc73e0302bc22)