### PR TITLE
Fix CycleAtlas map load button not being clickable

### DIFF
--- a/cycling_tracker.html
+++ b/cycling_tracker.html
@@ -146,6 +146,10 @@
       font-size: 0.8rem;
     }
 
+    .map-overlay button {
+      pointer-events: auto;
+    }
+
     .hint {
       font-size: 0.8rem;
       color: var(--muted);


### PR DESCRIPTION
### Motivation
- The overlay container for the map used `pointer-events: none`, which prevented interactive controls (like the Load Google Map button) from receiving clicks, so the map basemap could not be loaded from the UI.

### Description
- Added a CSS rule in `cycling_tracker.html` to enable pointer events on overlay buttons by adding `.map-overlay button { pointer-events: auto; }` so controls in the overlay are clickable.

### Testing
- Ran repository checks and commit commands (`git diff -- cycling_tracker.html`, `git status --short`, and the commit) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9780a6120832ab5ab405fc1f37638)